### PR TITLE
Updated the karma-requirejs version from 0.1.0 to 0.2.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,7 +35,7 @@
     "karma-chrome-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma": "~0.10.4",


### PR DESCRIPTION
The generator is failing because karma requires requirejs 0.2.0, but 0.1.0 is specified

```
npm ERR! peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma@0.10.10 wants karma-requirejs@~0.2.0
```
